### PR TITLE
Ext trg timestamp ship

### DIFF
--- a/firmware/mmc3_8_chip_multi_tx_eth_SHIP/src/mmc3_SHIP.xdc
+++ b/firmware/mmc3_8_chip_multi_tx_eth_SHIP/src/mmc3_SHIP.xdc
@@ -228,3 +228,5 @@ set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 set_property BITSTREAM.CONFIG.CONFIGRATE 33 [current_design]
 set_property CONFIG_VOLTAGE 3.3 [current_design]
 set_property CFGBVS VCCO [current_design]
+
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets LEMO_RX_IBUF[1]]

--- a/firmware/mmc3_8_chip_multi_tx_eth_SHIP/vivado/mmc3_8chip_multi_tx_eth_SHIP.xpr
+++ b/firmware/mmc3_8_chip_multi_tx_eth_SHIP/vivado/mmc3_8chip_multi_tx_eth_SHIP.xpr
@@ -3,7 +3,7 @@
 <!--                                                         -->
 <!-- Copyright 1986-2018 Xilinx, Inc. All Rights Reserved.   -->
 
-<Project Version="7" Minor="36" Path="Z:/dev/pyBAR/firmware/mmc3_8_chip_multi_tx_eth_SHIP/vivado/mmc3_8chip_multi_tx_eth_SHIP.xpr">
+<Project Version="7" Minor="36" Path="/home/silab/git/pybar/firmware/mmc3_8_chip_multi_tx_eth_SHIP/vivado/mmc3_8chip_multi_tx_eth_SHIP.xpr">
   <DefaultLaunch Dir="$PRUNDIR"/>
   <Configuration>
     <Option Name="Id" Val="bcfce6db9e8b493e8cb5b2b6871ddf7d"/>
@@ -53,7 +53,7 @@
   <FileSets Version="1" Minor="31">
     <FileSet Name="sources_1" Type="DesignSrcs" RelSrcDir="$PSRCDIR/sources_1">
       <Filter Type="Srcs"/>
-      <File Path="$PPRDIR/../src/XC7KSiTCPlib32k_V11/SiTCP_XC7K_32K_BBT_V110.ngc">
+      <File Path="$PPRDIR/../src/SiTCP/XC7KSiTCPlib32k_V11/SiTCP_XC7K_32K_BBT_V110.ngc">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
@@ -66,21 +66,21 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
-      <File Path="$PPRDIR/../src/XC7KSiTCPlib32k_V11/SiTCP_XC7K_32K_BBT_V110.V">
+      <File Path="$PPRDIR/../src/SiTCP/XC7KSiTCPlib32k_V11/SiTCP_XC7K_32K_BBT_V110.V">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
-      <File Path="$PPRDIR/../src/XC7KSiTCPlib32k_V11/TIMER.v">
+      <File Path="$PPRDIR/../src/SiTCP/XC7KSiTCPlib32k_V11/TIMER.v">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
-      <File Path="$PPRDIR/../src/XC7KSiTCPlib32k_V11/WRAP_SiTCP_GMII_XC7K_32K.V">
+      <File Path="$PPRDIR/../src/SiTCP/XC7KSiTCPlib32k_V11/WRAP_SiTCP_GMII_XC7K_32K.V">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
@@ -313,32 +313,43 @@
     <Simulator Name="Questa">
       <Option Name="Description" Val="Questa Advanced Simulator"/>
     </Simulator>
+    <Simulator Name="IES">
+      <Option Name="Description" Val="Incisive Enterprise Simulator (IES)"/>
+    </Simulator>
+    <Simulator Name="Xcelium">
+      <Option Name="Description" Val="Xcelium Parallel Simulator"/>
+    </Simulator>
+    <Simulator Name="VCS">
+      <Option Name="Description" Val="Verilog Compiler Simulator (VCS)"/>
+    </Simulator>
     <Simulator Name="Riviera">
       <Option Name="Description" Val="Riviera-PRO Simulator"/>
     </Simulator>
-    <Simulator Name="ActiveHDL">
-      <Option Name="Description" Val="Active-HDL Simulator"/>
-    </Simulator>
   </Simulators>
   <Runs Version="1" Minor="10">
-    <Run Id="synth_1" Type="Ft3:Synth" SrcSet="sources_1" Part="xc7k160tfbg676-1" ConstrsSet="constrs_1" Description="Higher performance designs, resource sharing is turned off, the global fanout guide is set to a lower number, FSM extraction forced to one-hot, LUT combining is disabled, equivalent registers are preserved, SRL are inferred  with a larger threshold" WriteIncrSynthDcp="false" State="current" IncludeInArchive="true">
+    <Run Id="synth_1" Type="Ft3:Synth" SrcSet="sources_1" Part="xc7k160tfbg676-1" ConstrsSet="constrs_1" Description="Higher performance designs, resource sharing is turned off, the global fanout guide is set to a lower number, FSM extraction forced to one-hot, LUT combining is disabled, equivalent registers are preserved, SRL are inferred  with a larger threshold" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/synth_1" IncludeInArchive="true">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Flow_PerfOptimized_high" Flow="Vivado Synthesis 2017"/>
+        <StratHandle Name="Flow_PerfOptimized_high" Flow="Vivado Synthesis 2017">
+          <Desc>Higher performance designs, resource sharing is turned off, the global fanout guide is set to a lower number, FSM extraction forced to one-hot, LUT combining is disabled, equivalent registers are preserved, SRL are inferred  with a larger threshold</Desc>
+        </StratHandle>
         <Step Id="synth_design">
-          <Option Id="RepFanoutThreshold">400</Option>
           <Option Id="KeepEquivalentRegisters">1</Option>
+          <Option Id="RepFanoutThreshold">400</Option>
           <Option Id="NoCombineLuts">1</Option>
-          <Option Id="FsmExtraction">1</Option>
           <Option Id="ResourceSharing">2</Option>
+          <Option Id="FsmExtraction">1</Option>
           <Option Id="ShregMinSize">5</Option>
         </Step>
       </Strategy>
+      <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy Name="Vivado Synthesis Default Reports" Flow="Vivado Synthesis 2017"/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7k160tfbg676-1" ConstrsSet="constrs_1" Description="Vivado Implementation Defaults" WriteIncrSynthDcp="false" State="current" SynthRun="synth_1" IncludeInArchive="true">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7k160tfbg676-1" ConstrsSet="constrs_1" Description="Vivado Implementation Defaults" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2015"/>
+        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2015">
+          <Desc>Vivado Implementation Defaults</Desc>
+        </StratHandle>
         <Step Id="init_design"/>
         <Step Id="opt_design"/>
         <Step Id="power_opt_design"/>
@@ -349,6 +360,7 @@
         <Step Id="post_route_phys_opt_design"/>
         <Step Id="write_bitstream"/>
       </Strategy>
+      <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy Name="Vivado Implementation Default Reports" Flow="Vivado Implementation 2017"/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
     </Run>

--- a/pybar/dut_configuration_mmc3_8chip_multi_tx_eth_SHiP.yaml
+++ b/pybar/dut_configuration_mmc3_8chip_multi_tx_eth_SHiP.yaml
@@ -1,0 +1,189 @@
+# MMC3 board with max. 8 FEI4s with multiple TX
+ETH:
+    ip : "192.168.10.16"
+    udp_port : 4660
+    tcp_port : 24
+    tcp_connection : True
+
+# Trigger
+TRIGGER_CH0:
+    TRIGGER_MODE                         : 0  # Selecting trigger mode: Use trigger inputs/trigger select (0), TLU no handshake (1), TLU simple handshake (2), TLU data handshake (3)
+    TRIGGER_SELECT                       : 512  # Selecting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_INVERT                       : 0  # Inverting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), LEMO RX0 synced with ext. trigger clock (512), disabled (0)
+    TRIGGER_VETO_SELECT                  : 1  # Selecting trigger veto: RX FIFO 0/1/2/3/4/4/6/7 full (2/4/8/16/32/64/128/256), FIFO full (1), disabled (0)
+    TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES : 3  # Increasing minimum trigger length in TLU data handshale mode (preventing certain TLU flaws)
+    TRIGGER_DATA_DELAY                   : 0  # TLU data handshake data delay depends on the cable length and should be adjusted with a delay scan (run scan/tune_tlu.py)
+    TRIGGER_THRESHOLD                    : 0  # Standard trigger minimum length in clock cycles of the trigger/TLU FSM
+    DATA_FORMAT                          : 1  # 31bit trigger number according to TRIGGER_MODE (0), 31bit time stamp (1), 15bit time stamp + 16bit trigger number (2)
+    USE_EXT_TIMESTAMP                    : 1  # if (1) the internal 31bit timestamp is replaced by a timestamp based on an external (40MHz) clock at LEMO RX1. Needs Trigger select 512
+
+TRIGGER_CH1:
+    TRIGGER_MODE                         : 0  # Selecting trigger mode: Use trigger inputs/trigger select (0), TLU no handshake (1), TLU simple handshake (2), TLU data handshake (3)
+    TRIGGER_SELECT                       : 4  # Selecting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_INVERT                       : 0  # Inverting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_VETO_SELECT                  : 1  # Selecting trigger veto: RX FIFO 0/1/2/3/4/4/6/7 full (2/4/8/16/32/64/128/256), FIFO full (1), disabled (0)
+    TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES : 3  # Increasing minimum trigger length in TLU data handshale mode (preventing certain TLU flaws)
+    TRIGGER_DATA_DELAY                   : 0  # TLU data handshake data delay depends on the cable length and should be adjusted with a delay scan (run scan/tune_tlu.py)
+    TRIGGER_THRESHOLD                    : 0  # Standard trigger minimum length in clock cycles of the trigger/TLU FSM
+    DATA_FORMAT                          : 0  # 31bit trigger number according to TRIGGER_MODE (0), 31bit time stamp (1), 15bit time stamp + 16bit trigger number (2)
+
+TRIGGER_CH2:
+    TRIGGER_MODE                         : 0  # Selecting trigger mode: Use trigger inputs/trigger select (0), TLU no handshake (1), TLU simple handshake (2), TLU data handshake (3)
+    TRIGGER_SELECT                       : 8  # Selecting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_INVERT                       : 0  # Inverting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_VETO_SELECT                  : 1  # Selecting trigger veto: RX FIFO 0/1/2/3/4/4/6/7 full (2/4/8/16/32/64/128/256), FIFO full (1), disabled (0)
+    TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES : 3  # Increasing minimum trigger length in TLU data handshale mode (preventing certain TLU flaws)
+    TRIGGER_DATA_DELAY                   : 0  # TLU data handshake data delay depends on the cable length and should be adjusted with a delay scan (run scan/tune_tlu.py)
+    TRIGGER_THRESHOLD                    : 0  # Standard trigger minimum length in clock cycles of the trigger/TLU FSM
+    DATA_FORMAT                          : 0  # 31bit trigger number according to TRIGGER_MODE (0), 31bit time stamp (1), 15bit time stamp + 16bit trigger number (2)
+
+TRIGGER_CH3:
+    TRIGGER_MODE                         : 0  # Selecting trigger mode: Use trigger inputs/trigger select (0), TLU no handshake (1), TLU simple handshake (2), TLU data handshake (3)
+    TRIGGER_SELECT                       : 16  # Selecting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_INVERT                       : 0  # Inverting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_VETO_SELECT                  : 1  # Selecting trigger veto: RX FIFO 0/1/2/3/4/4/6/7 full (2/4/8/16/32/64/128/256), FIFO full (1), disabled (0)
+    TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES : 3  # Increasing minimum trigger length in TLU data handshale mode (preventing certain TLU flaws)
+    TRIGGER_DATA_DELAY                   : 0  # TLU data handshake data delay depends on the cable length and should be adjusted with a delay scan (run scan/tune_tlu.py)
+    TRIGGER_THRESHOLD                    : 0  # Standard trigger minimum length in clock cycles of the trigger/TLU FSM
+    DATA_FORMAT                          : 0  # 31bit trigger number according to TRIGGER_MODE (0), 31bit time stamp (1), 15bit time stamp + 16bit trigger number (2)
+    USE_EXT_TIMESTAMP                    : 1  # if (1) the internal 31bit timestamp is replaced by a timestamp based on an external clock at LEMO RX1
+
+TRIGGER_CH4:
+    TRIGGER_MODE                         : 0  # Selecting trigger mode: Use trigger inputs/trigger select (0), TLU no handshake (1), TLU simple handshake (2), TLU data handshake (3)
+    TRIGGER_SELECT                       : 32  # Selecting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_INVERT                       : 0  # Inverting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_VETO_SELECT                  : 1  # Selecting trigger veto: RX FIFO 0/1/2/3/4/4/6/7 full (2/4/8/16/32/64/128/256), FIFO full (1), disabled (0)
+    TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES : 3  # Increasing minimum trigger length in TLU data handshale mode (preventing certain TLU flaws)
+    TRIGGER_DATA_DELAY                   : 0  # TLU data handshake data delay depends on the cable length and should be adjusted with a delay scan (run scan/tune_tlu.py)
+    TRIGGER_THRESHOLD                    : 0  # Standard trigger minimum length in clock cycles of the trigger/TLU FSM
+    DATA_FORMAT                          : 0  # 31bit trigger number according to TRIGGER_MODE (0), 31bit time stamp (1), 15bit time stamp + 16bit trigger number (2)
+
+TRIGGER_CH5:
+    TRIGGER_MODE                         : 0  # Selecting trigger mode: Use trigger inputs/trigger select (0), TLU no handshake (1), TLU simple handshake (2), TLU data handshake (3)
+    TRIGGER_SELECT                       : 64  # Selecting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_INVERT                       : 0  # Inverting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_VETO_SELECT                  : 1  # Selecting trigger veto: RX FIFO 0/1/2/3/4/4/6/7 full (2/4/8/16/32/64/128/256/256), FIFO full (1), disabled (0)
+    TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES : 3  # Increasing minimum trigger length in TLU data handshale mode (preventing certain TLU flaws)
+    TRIGGER_DATA_DELAY                   : 0  # TLU data handshake data delay depends on the cable length and should be adjusted with a delay scan (run scan/tune_tlu.py)
+    TRIGGER_THRESHOLD                    : 0  # Standard trigger minimum length in clock cycles of the trigger/TLU FSM
+    DATA_FORMAT                          : 0  # 31bit trigger number according to TRIGGER_MODE (0), 31bit time stamp (1), 15bit time stamp + 16bit trigger number (2)
+
+TRIGGER_CH6:
+    TRIGGER_MODE                         : 0  # Selecting trigger mode: Use trigger inputs/trigger select (0), TLU no handshake (1), TLU simple handshake (2), TLU data handshake (3)
+    TRIGGER_SELECT                       : 128  # Selecting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_INVERT                       : 0  # Inverting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_VETO_SELECT                  : 1  # Selecting trigger veto: RX FIFO 0/1/2/3/4/4/6/7 full (2/4/8/16/32/64/128/256), FIFO full (1), disabled (0)
+    TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES : 3  # Increasing minimum trigger length in TLU data handshale mode (preventing certain TLU flaws)
+    TRIGGER_DATA_DELAY                   : 0  # TLU data handshake data delay depends on the cable length and should be adjusted with a delay scan (run scan/tune_tlu.py)
+    TRIGGER_THRESHOLD                    : 0  # Standard trigger minimum length in clock cycles of the trigger/TLU FSM
+    DATA_FORMAT                          : 0  # 31bit trigger number according to TRIGGER_MODE (0), 31bit time stamp (1), 15bit time stamp + 16bit trigger number (2)
+
+TRIGGER_CH7:
+    TRIGGER_MODE                         : 0  # Selecting trigger mode: Use trigger inputs/trigger select (0), TLU no handshake (1), TLU simple handshake (2), TLU data handshake (3)
+    TRIGGER_SELECT                       : 256  # Selecting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_INVERT                       : 0  # Inverting trigger input: MonHit/HitOR from module 0/1/2/3/4/5/6/7 (2/4/8/16/32/64/128/256), LEMO RX0 (1), disabled (0)
+    TRIGGER_VETO_SELECT                  : 1  # Selecting trigger veto: RX FIFO 0/1/2/3/4/4/6/7 full (2/4/8/16/32/64/128/256), FIFO full (1), disabled (0)
+    TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES : 3  # Increasing minimum trigger length in TLU data handshale mode (preventing certain TLU flaws)
+    TRIGGER_DATA_DELAY                   : 0  # TLU data handshake data delay depends on the cable length and should be adjusted with a delay scan (run scan/tune_tlu.py)
+    TRIGGER_THRESHOLD                    : 0  # Standard trigger minimum length in clock cycles of the trigger/TLU FSM
+    DATA_FORMAT                          : 0  # 31bit trigger number according to TRIGGER_MODE (0), 31bit time stamp (1), 15bit time stamp + 16bit trigger number (2)
+
+# TDC for high precision charge measurements
+TDC_CH0:
+    EN_WRITE_TIMESTAMP   : 1  # Writing trigger timestamp
+    EN_TRIGGER_DIST      : 0  # Measuring trigger to TDC delay with 640MHz clock
+    EN_NO_WRITE_TRIG_ERR : 0  # Writing TDC word only if valid trigger occurred
+    EN_INVERT_TDC        : 0  # Inverting TDC input
+    EN_INVERT_TRIGGER    : 0  # Inverting trigger input
+
+TDC_CH1:
+    EN_WRITE_TIMESTAMP   : 1  # Writing trigger timestamp
+    EN_TRIGGER_DIST      : 0  # Measuring trigger to TDC delay with 640MHz clock
+    EN_NO_WRITE_TRIG_ERR : 0  # Writing TDC word only if valid trigger occurred
+    EN_INVERT_TDC        : 0  # Inverting TDC input
+    EN_INVERT_TRIGGER    : 0  # Inverting trigger input
+
+TDC_CH2:
+    EN_WRITE_TIMESTAMP   : 1  # Writing trigger timestamp
+    EN_TRIGGER_DIST      : 0  # Measuring trigger to TDC delay with 640MHz clock
+    EN_NO_WRITE_TRIG_ERR : 0  # Writing TDC word only if valid trigger occurred
+    EN_INVERT_TDC        : 0  # Inverting TDC input
+    EN_INVERT_TRIGGER    : 0  # Inverting trigger input
+
+TDC_CH3:
+    EN_WRITE_TIMESTAMP   : 1  # Writing trigger timestamp
+    EN_TRIGGER_DIST      : 0  # Measuring trigger to TDC delay with 640MHz clock
+    EN_NO_WRITE_TRIG_ERR : 0  # Writing TDC word only if valid trigger occurred
+    EN_INVERT_TDC        : 0  # Inverting TDC input
+    EN_INVERT_TRIGGER    : 0  # Inverting trigger input
+
+TDC_CH4:
+    EN_WRITE_TIMESTAMP   : 1  # Writing trigger timestamp
+    EN_TRIGGER_DIST      : 0  # Measuring trigger to TDC delay with 640MHz clock
+    EN_NO_WRITE_TRIG_ERR : 0  # Writing TDC word only if valid trigger occurred
+    EN_INVERT_TDC        : 0  # Inverting TDC input
+    EN_INVERT_TRIGGER    : 0  # Inverting trigger input
+
+TDC_CH5:
+    EN_WRITE_TIMESTAMP   : 1  # Writing trigger timestamp
+    EN_TRIGGER_DIST      : 0  # Measuring trigger to TDC delay with 640MHz clock
+    EN_NO_WRITE_TRIG_ERR : 0  # Writing TDC word only if valid trigger occurred
+    EN_INVERT_TDC        : 0  # Inverting TDC input
+    EN_INVERT_TRIGGER    : 0  # Inverting trigger input
+
+TDC_CH6:
+    EN_WRITE_TIMESTAMP   : 1  # Writing trigger timestamp
+    EN_TRIGGER_DIST      : 0  # Measuring trigger to TDC delay with 640MHz clock
+    EN_NO_WRITE_TRIG_ERR : 0  # Writing TDC word only if valid trigger occurred
+    EN_INVERT_TDC        : 0  # Inverting TDC input
+    EN_INVERT_TRIGGER    : 0  # Inverting trigger input
+
+# FE-I4 command output
+CMD_CH0:
+    OUTPUT_MODE : 3  # Selecting command output mode: positive edge (0), negative edge (1), Manchester Code according to IEEE 802.3 (2), Manchester Code according to G.E. Thomas (3)
+
+CMD_CH1:
+    OUTPUT_MODE : 3  # Selecting command output mode: positive edge (0), negative edge (1), Manchester Code according to IEEE 802.3 (2), Manchester Code according to G.E. Thomas (3)
+
+CMD_CH2:
+    OUTPUT_MODE : 3  # Selecting command output mode: positive edge (0), negative edge (1), Manchester Code according to IEEE 802.3 (2), Manchester Code according to G.E. Thomas (3)
+
+CMD_CH3:
+    OUTPUT_MODE : 3  # Selecting command output mode: positive edge (0), negative edge (1), Manchester Code according to IEEE 802.3 (2), Manchester Code according to G.E. Thomas (3)
+
+CMD_CH4:
+    OUTPUT_MODE : 3  # Selecting command output mode: positive edge (0), negative edge (1), Manchester Code according to IEEE 802.3 (2), Manchester Code according to G.E. Thomas (3)
+
+CMD_CH5:
+    OUTPUT_MODE : 3  # Selecting command output mode: positive edge (0), negative edge (1), Manchester Code according to IEEE 802.3 (2), Manchester Code according to G.E. Thomas (3)
+
+CMD_CH6:
+    OUTPUT_MODE : 3  # Selecting command output mode: positive edge (0), negative edge (1), Manchester Code according to IEEE 802.3 (2), Manchester Code according to G.E. Thomas (3)
+
+CMD_CH7:
+    OUTPUT_MODE : 3  # Selecting command output mode: positive edge (0), negative edge (1), Manchester Code according to IEEE 802.3 (2), Manchester Code according to G.E. Thomas (3)
+
+# FE-I4 data receivers
+DATA_CH0:
+    INVERT_RX : 0  # Inverting data input: disabled (0), enabled (e.g. for DBM modules) (1)
+
+DATA_CH1:
+    INVERT_RX : 0  # Inverting data input: disabled (0), enabled (e.g. for DBM modules) (1)
+
+DATA_CH2:
+    INVERT_RX : 0  # Inverting data input: disabled (0), enabled (e.g. for DBM modules) (1)
+
+DATA_CH3:
+    INVERT_RX : 0  # Inverting data input: disabled (0), enabled (e.g. for DBM modules) (1)
+
+DATA_CH4:
+    INVERT_RX : 0  # Inverting data input: disabled (0), enabled (e.g. for DBM modules) (1)
+
+DATA_CH5:
+    INVERT_RX : 0  # Inverting data input: disabled (0), enabled (e.g. for DBM modules) (1)
+
+DATA_CH6:
+    INVERT_RX : 0  # Inverting data input: disabled (0), enabled (e.g. for DBM modules) (1)
+
+DATA_CH7:
+    INVERT_RX : 0  # Inverting data input: disabled (0), enabled (e.g. for DBM modules) (1)


### PR DESCRIPTION
new firmware with top module for SHiP testbeam, acceptance of external clock between 20 and 50 MHz for a trigger_time_stamp counter. The counter can be used by the basil tlu module.